### PR TITLE
Make install command more precise

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ More information is available [here](https://jeskin.net/blog/clp/), along with a
 
 ```
 brew tap jpe90/clp
-brew install clp
+brew install jpe90/clp/clp
 ```
 
 ### Building from source


### PR DESCRIPTION
to work around the naming clash with another "clp" package in homebrew (the COIN-OR Linear Programming Solver).