### PR TITLE
allow bright & multiple params in ansi_string_4b

### DIFF
--- a/lua/ansi_codes.lua
+++ b/lua/ansi_codes.lua
@@ -24,6 +24,15 @@ local sgr_params = {
     cyan = 36,
     white = 37,
 
+    brblack = 90,
+    brred = 91,
+    brgreen = 92,
+    bryellow = 93,
+    brblue = 94,
+    brmagenta = 95,
+    brcyan = 96,
+    brwhite = 97,
+
     -- background
     onblack = 40,
     onred = 41,
@@ -32,7 +41,16 @@ local sgr_params = {
     onblue = 44,
     onmagenta = 45,
     oncyan = 46,
-    onwhite = 47
+    onwhite = 47,
+
+    onbrblack = 100,
+    onbrred = 101,
+    onbrgreen = 102,
+    onbryellow = 103,
+    onbrblue = 104,
+    onbrmagenta = 105,
+    onbrcyan = 106,
+    onbrwhite = 107
 }
 
 local function hex_to_rgb(hex)

--- a/lua/ansi_codes.lua
+++ b/lua/ansi_codes.lua
@@ -62,7 +62,12 @@ local function ansi_string_4b(color)
     local ansi_code = ""
     for attr, value in pairs(color) do
         if attr == "color" then
-            ansi_code = ansi_code .. ansi_string(sgr_params[value])
+            for param in string.gmatch(value, "[^%s]+") do
+                local code = sgr_params[param]
+                if code ~= nil then
+                    ansi_code = ansi_code .. ansi_string(code)
+                end
+            end
         else
             print('error in 4 bit color value')
         end


### PR DESCRIPTION
i added bright color variants to `sgr_params` so that you can use the bright variants of colors (`brred` for bright red for example). these are different to using the bright sgr param.

i also made it so that the color string is parsed as space delimited words so that you can have multiple params in a color.
for example `underscore brblack` will add both the underscore param and the bright black param.

none of these changes are breaking since the previous syntax for defining a color works with the space delimited words syntax (its just one word).